### PR TITLE
Add a WithTimescaleDB option to support using the Timescale PG compatible images

### DIFF
--- a/options.go
+++ b/options.go
@@ -60,16 +60,23 @@ func WithImageTag(tag string) Option {
 	return imageTagOption(tag)
 }
 
-type repositoryOption string
+type useTimescaleDBOption bool
 
-func (t repositoryOption) apply(opts *options) {
-	opts.repository = string(t)
+func (t useTimescaleDBOption) apply(opts *options) {
+	opts.repository = "timescale/timescaledb"
+
+	// Set to a valid image tag, but don't override unless it is the
+	// default.
+	if opts.imageTag == "alpine" {
+		opts.imageTag = "latest-pg15"
+	}
 }
 
-// WithImageTag configures the PSQL Container repository where the
-// image image tag, default: postgres
-func WithRepository(repo string) Option {
-	return repositoryOption(repo)
+// WithTimescaleDB allows using the TimescaleDB repository and
+// images. This option also updates the image tag to 'latest-pg15' as
+// the default alpine is invalid.
+func WithTimescaleDB() Option {
+	return useTimescaleDBOption(true)
 }
 
 type sqlOption string

--- a/options.go
+++ b/options.go
@@ -62,7 +62,7 @@ func WithImageTag(tag string) Option {
 
 type useTimescaleDBOption bool
 
-func (t useTimescaleDBOption) apply(opts *options) {
+func (useTimescaleDBOption) apply(opts *options) {
 	opts.repository = "timescale/timescaledb"
 
 	// Set to a valid image tag, but don't override unless it is the

--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ type options struct {
 	containerName,
 	imageTag,
 	poolEndpoint,
+	repository,
 	dbPort string
 	sqls              []string
 	pool              *dockertest.Pool
@@ -21,6 +22,7 @@ func defaultOptions() options {
 	return options{
 		containerName:     "go-psqldocker",
 		imageTag:          "alpine",
+		repository:        "postgres",
 		poolEndpoint:      "",
 		dbPort:            "5432",
 		sqls:              nil,
@@ -56,6 +58,18 @@ func (t imageTagOption) apply(opts *options) {
 // WithImageTag configures the PSQL Container image tag, default: alpine.
 func WithImageTag(tag string) Option {
 	return imageTagOption(tag)
+}
+
+type repositoryOption string
+
+func (t repositoryOption) apply(opts *options) {
+	opts.repository = string(t)
+}
+
+// WithImageTag configures the PSQL Container repository where the
+// image image tag, default: postgres
+func WithRepository(repo string) Option {
+	return repositoryOption(repo)
 }
 
 type sqlOption string

--- a/psql_container.go
+++ b/psql_container.go
@@ -89,7 +89,7 @@ func initContainer(user,
 		runOptions: &dockertest.RunOptions{
 			Name:         options.containerName,
 			Cmd:          []string{"-p " + options.dbPort},
-			Repository:   "postgres",
+			Repository:   options.repository,
 			Tag:          options.imageTag,
 			ExposedPorts: []string{options.dbPort},
 			Env:          envVars(user, password, dbName),

--- a/psql_container_test.go
+++ b/psql_container_test.go
@@ -70,6 +70,43 @@ func TestNewContainer(t *testing.T) {
 		i.NoErr(err)
 	})
 
+	t.Run("WithTimescaleDBOption", func(t *testing.T) {
+		t.Parallel()
+
+		i := is.New(t)
+
+		c, err := psqldocker.NewContainer(
+			user,
+			password,
+			dbName,
+			psqldocker.WithTimescaleDB(),
+			psqldocker.WithContainerName(containerNameFromTest(t)),
+		)
+		i.NoErr(err)
+
+		err = c.Close()
+		i.NoErr(err)
+	})
+
+	t.Run("WithTimescaleDBOptionAndCustomTag", func(t *testing.T) {
+		t.Parallel()
+
+		i := is.New(t)
+
+		c, err := psqldocker.NewContainer(
+			user,
+			password,
+			dbName,
+			psqldocker.WithImageTag("latest-pg14"),
+			psqldocker.WithTimescaleDB(),
+			psqldocker.WithContainerName(containerNameFromTest(t)),
+		)
+		i.NoErr(err)
+
+		err = c.Close()
+		i.NoErr(err)
+	})
+
 	t.Run("InvalidTagFormat", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
This allows support for using Postgres compatible images such as TimescaleDB via:

```
psqldocker.NewContainer(
	u, p, dbname,
	psqldocker.WithRepository("timescale/timescaledb-ha"),
	psqldocker.WithImageTag("pg15-latest"),
)
```